### PR TITLE
MTDSA-3111 - Added specific JSON validation errors

### DIFF
--- a/app/v2/controllers/requestParsers/CrystallisationRequestDataParser.scala
+++ b/app/v2/controllers/requestParsers/CrystallisationRequestDataParser.scala
@@ -20,18 +20,17 @@ import javax.inject.Inject
 import uk.gov.hmrc.domain.Nino
 import v2.controllers.requestParsers.validators.CrystallisationValidator
 import v2.models.domain.CrystallisationRequest
-import v2.models.errors.{BadRequestError, ErrorWrapper}
-import v2.models.requestData.{CrystallisationRawData, CrystallisationRequestData, DesTaxYear}
+import v2.models.errors.{ BadRequestError, ErrorWrapper }
+import v2.models.requestData.{ CrystallisationRawData, CrystallisationRequestData, DesTaxYear }
 
 class CrystallisationRequestDataParser @Inject()(validator: CrystallisationValidator) {
 
   def parseRequest(data: CrystallisationRawData): Either[ErrorWrapper, CrystallisationRequestData] = {
     validator.validate(data) match {
-      case Nil =>
-        //Validation passed.  Request data is ok to transform.
-        Right(CrystallisationRequestData(Nino(data.nino), DesTaxYear.fromMtd(data.taxYear), data.body.json.as[CrystallisationRequest]))
-      case err :: Nil => Left(ErrorWrapper(None, err, None))
-      case errs => Left(ErrorWrapper(None, BadRequestError, Some(errs)))
+      case Nil                                       => Right(CrystallisationRequestData(Nino(data.nino), DesTaxYear.fromMtd(data.taxYear), data.body.json.as[CrystallisationRequest]))
+      case err :: Nil if err.code.startsWith("JSON") => Left(ErrorWrapper(None, BadRequestError, Some(List(err))))
+      case err :: Nil                                => Left(ErrorWrapper(None, err, None))
+      case errs                                      => Left(ErrorWrapper(None, BadRequestError, Some(errs)))
     }
   }
 

--- a/app/v2/controllers/requestParsers/IntentToCrystalliseRequestDataParser.scala
+++ b/app/v2/controllers/requestParsers/IntentToCrystalliseRequestDataParser.scala
@@ -19,17 +19,17 @@ package v2.controllers.requestParsers
 import javax.inject.Inject
 import uk.gov.hmrc.domain.Nino
 import v2.controllers.requestParsers.validators.IntentToCrystalliseValidator
-import v2.models.errors.{BadRequestError, ErrorWrapper}
-import v2.models.requestData.{DesTaxYear, IntentToCrystalliseRawData, IntentToCrystalliseRequestData}
+import v2.models.errors.{ BadRequestError, ErrorWrapper }
+import v2.models.requestData.{ DesTaxYear, IntentToCrystalliseRawData, IntentToCrystalliseRequestData }
 
 class IntentToCrystalliseRequestDataParser @Inject()(validator: IntentToCrystalliseValidator) {
 
   def parseRequest(data: IntentToCrystalliseRawData): Either[ErrorWrapper, IntentToCrystalliseRequestData] = {
     validator.validate(data) match {
-      case Nil =>
-        Right(IntentToCrystalliseRequestData(Nino(data.nino), DesTaxYear.fromMtd(data.taxYear)))
-      case err :: Nil => Left(ErrorWrapper(None, err, None))
-      case errs => Left(ErrorWrapper(None, BadRequestError, Some(errs)))
+      case Nil                                       => Right(IntentToCrystalliseRequestData(Nino(data.nino), DesTaxYear.fromMtd(data.taxYear)))
+      case err :: Nil if err.code.startsWith("JSON") => Left(ErrorWrapper(None, BadRequestError, Some(List(err))))
+      case err :: Nil                                => Left(ErrorWrapper(None, err, None))
+      case errs                                      => Left(ErrorWrapper(None, BadRequestError, Some(errs)))
     }
   }
 

--- a/app/v2/controllers/requestParsers/validators/CrystallisationValidator.scala
+++ b/app/v2/controllers/requestParsers/validators/CrystallisationValidator.scala
@@ -18,14 +18,12 @@ package v2.controllers.requestParsers.validators
 
 import v2.controllers.requestParsers.validators.validations._
 import v2.models.domain.CrystallisationRequest
-import v2.models.errors.{Error, RuleIncorrectOrEmptyBodyError, RuleTaxYearNotSupportedError}
+import v2.models.errors.{ Error, RuleTaxYearNotSupportedError }
 import v2.models.requestData.CrystallisationRawData
 
 class CrystallisationValidator extends Validator[CrystallisationRawData] {
 
-  private val validationSet = List(
-    parameterFormatValidation, bodyFormatValidator,
-    parameterRuleValidation, bodyFieldsValidation)
+  private val validationSet = List(parameterFormatValidation, bodyFormatValidator, parameterRuleValidation, bodyFieldsValidation)
 
   private def parameterFormatValidation: CrystallisationRawData => List[List[Error]] = (data: CrystallisationRawData) => {
     List(
@@ -42,7 +40,7 @@ class CrystallisationValidator extends Validator[CrystallisationRawData] {
 
   private def bodyFormatValidator: CrystallisationRawData => List[List[Error]] = { data =>
     List(
-      JsonFormatValidation.validate[CrystallisationRequest](data.body, RuleIncorrectOrEmptyBodyError)
+      JsonFormatValidation.validate[CrystallisationRequest](data.body)
     )
   }
 

--- a/app/v2/controllers/requestParsers/validators/validations/JsonFormatValidation.scala
+++ b/app/v2/controllers/requestParsers/validators/validations/JsonFormatValidation.scala
@@ -16,19 +16,54 @@
 
 package v2.controllers.requestParsers.validators.validations
 
+import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc.AnyContentAsJson
-import v2.models.errors.Error
+import v2.models.errors.{ BadRequestError, Error }
 
 object JsonFormatValidation {
 
-  def validate[A](data: AnyContentAsJson, error: Error)(implicit reads: Reads[A]): List[Error] = {
+  val JSON_FIELD_MISSING    = "JSON_FIELD_MISSING"
+  val JSON_STRING_EXPECTED  = "JSON_STRING_EXPECTED"
+  val JSON_NUMBER_EXPECTED  = "JSON_NUMBER_EXPECTED"
+  val JSON_INTEGER_EXPECTED = "JSON_INTEGER_EXPECTED"
+  val JSON_BOOLEAN_EXPECTED = "JSON_BOOLEAN_EXPECTED"
+  val JSON_OBJECT_EXPECTED  = "JSON_OBJECT_EXPECTED"
+  val JSON_ARRAY_EXPECTED   = "JSON_ARRAY_EXPECTED"
+
+  private val logger: Logger = Logger(this.getClass)
+
+  def validate[A](data: AnyContentAsJson)(implicit reads: Reads[A]): List[Error] = {
 
     data.json.validate[A] match {
       case JsSuccess(_, _) => NoValidationErrors
-      case _ => List(error)
+      case JsError(errors) => convertJsErrors(errors)
     }
 
   }
+
+  private def convertJsErrors(errors: Seq[(JsPath, Seq[JsonValidationError])]): List[Error] = {
+    errors.toList.flatMap { data =>
+      val (path, jsonValidationErrors) = data
+      jsonValidationErrors.flatMap(error => mapSingleJsError(error, path))
+    }
+  }
+
+  private def mapSingleJsError(jsonError: JsonValidationError, path: JsPath): List[Error] = {
+    jsonError.messages.map {
+      case "error.path.missing"      => Error(JSON_FIELD_MISSING, s"$path is missing")
+      case "error.expected.jsstring" => Error(JSON_STRING_EXPECTED, s"$path should be a valid JSON string")
+      case "error.expected.numberformatexception" | "error.expected.jsnumberorjsstring" =>
+        Error(JSON_NUMBER_EXPECTED, s"$path should be a valid JSON number")
+      case "error.expected.int"       => Error(JSON_INTEGER_EXPECTED, s"$path should be a valid integer")
+      case "error.expected.jsboolean" => Error(JSON_BOOLEAN_EXPECTED, s"$path should be a valid JSON boolean")
+      case "error.expected.jsobject"  => Error(JSON_OBJECT_EXPECTED, s"$path should be a valid JSON object")
+      case "error.expected.jsarray"   => Error(JSON_ARRAY_EXPECTED, s"$path should be a valid JSON array")
+      case unmatched => {
+        logger.warn(s"[JsonFormatValidation][mapSingleJsError] - Received '$unmatched' error type and was unable to map")
+        BadRequestError
+      }
+    }
+  }.toList
 
 }

--- a/test/v2/controllers/requestParsers/validators/CrystallisationValidatorSpec.scala
+++ b/test/v2/controllers/requestParsers/validators/CrystallisationValidatorSpec.scala
@@ -24,7 +24,7 @@ import v2.models.requestData.CrystallisationRawData
 
 class CrystallisationValidatorSpec extends UnitSpec {
 
-  private val validNino = "AA123456A"
+  private val validNino    = "AA123456A"
   private val validTaxYear = "2018-19"
 
   private val validJson =
@@ -60,9 +60,8 @@ class CrystallisationValidatorSpec extends UnitSpec {
 
     "return RuleTaxYearNotSupportedError error" when {
       "an out of range tax year is supplied" in {
-                        validator.validate(
-                          CrystallisationRawData(validNino, "2016-17",  body(validJson))) shouldBe
-                            List(RuleTaxYearNotSupportedError)
+        validator.validate(CrystallisationRawData(validNino, "2016-17", body(validJson))) shouldBe
+          List(RuleTaxYearNotSupportedError)
       }
     }
 
@@ -82,20 +81,23 @@ class CrystallisationValidatorSpec extends UnitSpec {
 
     "return RuleIncorrectOrEmptyBodyError error" when {
       "an empty body is supplied" in {
-        val json = "{}"
+        val json          = "{}"
+        val expectedError = Error("JSON_FIELD_MISSING", "/calculationId is missing")
 
         validator.validate(
           CrystallisationRawData(validNino, validTaxYear, body(json))
-        ) shouldBe List(RuleIncorrectOrEmptyBodyError)
+        ) shouldBe List(expectedError)
       }
 
-      "an the body does not contain a calculationId" in {
-        val json = """{"someField": 1234}"""
+      "the body does not contain a calculationId" in {
+        val json          = """{"someField": 1234}"""
+        val expectedError = Error("JSON_FIELD_MISSING", "/calculationId is missing")
 
         validator.validate(
           CrystallisationRawData(validNino, validTaxYear, body(json))
-        ) shouldBe List(RuleIncorrectOrEmptyBodyError)
+        ) shouldBe List(expectedError)
       }
+
     }
 
     "return multiple errors" when {

--- a/test/v2/controllers/requestParsers/validators/validations/JsonFormatValidationSpec.scala
+++ b/test/v2/controllers/requestParsers/validators/validations/JsonFormatValidationSpec.scala
@@ -16,7 +16,7 @@
 
 package v2.controllers.requestParsers.validators.validations
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{ Json, Reads }
 import play.api.mvc.AnyContentAsJson
 import support.UnitSpec
 import v2.models.errors.Error
@@ -24,34 +24,462 @@ import v2.models.utils.JsonErrorValidators
 
 class JsonFormatValidationSpec extends UnitSpec with JsonErrorValidators {
 
-  case class TestDataObject(fieldOne: String, fieldTwo: String)
+  case class Person(
+      fullName: String,
+      totalWorth: BigDecimal,
+      namesOfChildren: List[String],
+      noOfChildren: Int,
+      employed: Boolean,
+      favouriteBook: Book,
+      topSecretPassword: Option[String]
+  )
 
-  implicit val testDataObjectReads: Reads[TestDataObject] = Json.reads[TestDataObject]
+  case class Book(title: String, author: String)
 
-  val dummyError = Error("DUMMY_CODE", "dummy message")
+  implicit val bookReads: Reads[Book]     = Json.reads[Book]
+  implicit val personReads: Reads[Person] = Json.reads[Person]
 
   "validate" should {
+
     "return no errors" when {
-      "when a valid JSON object with all the necessary fields is supplied" in {
 
-        val validJson = AnyContentAsJson(Json.parse("""{ "fieldOne" : "Something", "fieldTwo" : "SomethingElse" }"""))
+      "a valid JSON object with all the necessary fields is supplied" in {
 
-        val validationResult = JsonFormatValidation.validate[TestDataObject](validJson, dummyError)
-        validationResult shouldBe empty
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.isEmpty shouldBe true
+
       }
+
+      "a valid JSON object with optional fields missing is supplied" in {
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    }
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.isEmpty shouldBe true
+
+      }
+
+      "a valid JSON object with quoted decimal values" in {
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": "1234567.88",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.isEmpty shouldBe true
+
+      }
+
     }
 
-    "return an error " when {
-      "when a required field is missing" in {
+    "return an error" when {
 
-        // fieldTwo is missing
-        val json = AnyContentAsJson(Json.parse("""{ "fieldOne" : "Something" }"""))
+      "a required field is missing" in {
 
-        val validationResult = JsonFormatValidation.validate[TestDataObject](json, dummyError)
-        validationResult shouldBe List(dummyError)
+        val expectedError = Error(JsonFormatValidation.JSON_FIELD_MISSING, "/totalWorth is missing")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a string type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/fullName should be a valid JSON string")
+
+        val json =
+          """
+            |{
+            |    "fullName": 101010101110,
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a number type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_NUMBER_EXPECTED, "/totalWorth should be a valid JSON number")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": "Timothy James Barnes",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a boolean type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_BOOLEAN_EXPECTED, "/employed should be a valid JSON boolean")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": "Yes Sir",
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an integer type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_INTEGER_EXPECTED, "/noOfChildren should be a valid integer")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 7.7,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an object is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_OBJECT_EXPECTED, "/favouriteBook should be a valid JSON object")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": "Kite Runner",
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a decimal value is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_NUMBER_EXPECTED, "/totalWorth should be a valid JSON number")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": { "net": 2500 },
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an array is required but another type is provided" in {
+        val expectedError = Error(JsonFormatValidation.JSON_ARRAY_EXPECTED, "/namesOfChildren should be a valid JSON array")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": "Timmy and Tommy",
+            |    "noOfChildren" : 2,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an error occurs below the first level of the json data" in {
+        val expectedError = Error(JsonFormatValidation.JSON_FIELD_MISSING, "/favouriteBook/title is missing")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+      }
+
+    }
+
+    "return multiple errors" when {
+
+      "invalid types are provided in an array" in {
+
+        val expectedErrorOne   = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/namesOfChildren(0) should be a valid JSON string")
+        val expectedErrorTwo   = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/namesOfChildren(1) should be a valid JSON string")
+        val expectedErrorThree = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/namesOfChildren(2) should be a valid JSON string")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [ 1, 2, 3 ],
+            |    "noOfChildren" : 3,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 3
+        validationResult.contains(expectedErrorOne) shouldBe true
+        validationResult.contains(expectedErrorTwo) shouldBe true
+        validationResult.contains(expectedErrorThree) shouldBe true
+
+      }
+
+      "multiple incorrect types are provided" in {
+
+        val expectedErrorOne = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/fullName should be a valid JSON string")
+        val expectedErrorTwo = Error(JsonFormatValidation.JSON_NUMBER_EXPECTED, "/totalWorth should be a valid JSON number")
+
+        val json =
+          """
+            |{
+            |    "fullName": 1234567.88,
+            |    "totalWorth": "Timothy James Barnes",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+
+        validationResult.size shouldBe 2
+        validationResult.contains(expectedErrorOne) shouldBe true
+        validationResult.contains(expectedErrorTwo) shouldBe true
+
       }
 
     }
 
   }
+
 }


### PR DESCRIPTION
Needs discussion before merging. 

By implementing this validation we essentially make the `RULE_EMPTY_BODY_JSON` error redundant and it will no longer be returned. It is in the RAML documentation but will no longer be returned for this microservice.