### PR TITLE
Possible endpoint simplification

### DIFF
--- a/app/v2/controllers/DesResponseMappingSupport.scala
+++ b/app/v2/controllers/DesResponseMappingSupport.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers
+
+import play.api.Logger
+import v2.models.errors.{ BadRequestError, DesError, DownstreamError, Error, ErrorWrapper, MultipleErrors, OutboundError, SingleError }
+import v2.models.outcomes.DesResponse
+
+trait DesResponseMappingSupport {
+
+  /**
+    * Controller name for logging
+    */
+  val controllerName: String
+
+  protected val logger: Logger = Logger(this.getClass)
+
+  final def mapDesErrors[D](endpointName: String, errorMap: PartialFunction[String, Error])(desOutcome: DesResponse[DesError]): ErrorWrapper = {
+
+    lazy val defaultErrorMapping: String => Error = { code =>
+      logger.info(s"[$controllerName] [$endpointName] - No mapping found for error code $code")
+      DownstreamError
+    }
+
+    desOutcome match {
+      case DesResponse(correlationId, MultipleErrors(errors)) =>
+        val mtdErrors = errors.map(error => errorMap.applyOrElse(error.code, defaultErrorMapping))
+
+        if (mtdErrors.contains(DownstreamError)) {
+          logger.info(
+            s"[$controllerName] [$endpointName] [CorrelationId - $correlationId]" +
+              s" - downstream returned ${errors.map(_.code).mkString(",")}. Revert to ISE")
+          ErrorWrapper(Some(correlationId), DownstreamError, None)
+        } else {
+          ErrorWrapper(Some(correlationId), BadRequestError, Some(mtdErrors))
+        }
+
+      case DesResponse(correlationId, SingleError(error)) =>
+        ErrorWrapper(Some(correlationId), errorMap.applyOrElse(error.code, defaultErrorMapping), None)
+      case DesResponse(correlationId, OutboundError(error)) =>
+        ErrorWrapper(Some(correlationId), error, None)
+    }
+  }
+}

--- a/app/v2/models/outcomes/DesResponse.scala
+++ b/app/v2/models/outcomes/DesResponse.scala
@@ -16,4 +16,6 @@
 
 package v2.models.outcomes
 
-case class DesResponse[+T](correlationId: String, responseData: T)
+case class DesResponse[+A](correlationId: String, responseData: A) {
+  def map[B](f: A => B): DesResponse[B] = DesResponse(correlationId, f(responseData))
+}

--- a/app/v2/services/CrystallisationService.scala
+++ b/app/v2/services/CrystallisationService.scala
@@ -49,14 +49,14 @@ class CrystallisationService @Inject()(connector: DesConnector) extends DesServi
 
   private def desErrorToMtdErrorIntent: Map[String, Error] =
     Map(
-      "INVALID_NINO"               -> NinoFormatError,
-      "INVALID_TAX_YEAR"           -> TaxYearFormatError,
-      "INVALID_TAX_CRYSTALLISE"    -> DownstreamError,
-      "INVALID_REQUEST"            -> DownstreamError,
-      "NO_SUBMISSION_EXIST"        -> NoSubmissionsExistError,
-      "CONFLICT"                   -> FinalDeclarationReceivedError,
-      "SERVER_ERROR"               -> DownstreamError,
-      "SERVICE_UNAVAILABLE"        -> DownstreamError
+      "INVALID_NINO"            -> NinoFormatError,
+      "INVALID_TAX_YEAR"        -> TaxYearFormatError,
+      "INVALID_TAX_CRYSTALLISE" -> DownstreamError,
+      "INVALID_REQUEST"         -> DownstreamError,
+      "NO_SUBMISSION_EXIST"     -> NoSubmissionsExistError,
+      "CONFLICT"                -> FinalDeclarationReceivedError,
+      "SERVER_ERROR"            -> DownstreamError,
+      "SERVICE_UNAVAILABLE"     -> DownstreamError
     )
 
   private def desErrorToMtdErrorCreate: Map[String, Error] =

--- a/app/v2/services/DesService.scala
+++ b/app/v2/services/DesService.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.services
+
+import javax.inject.Inject
+import play.api.libs.json.{ Reads, Writes }
+import uk.gov.hmrc.http.logging.Authorization
+import uk.gov.hmrc.http.{ HeaderCarrier, HttpReads }
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import v2.config.AppConfig
+import v2.connectors.DesConnectorOutcome
+import v2.connectors.httpparsers.StandardDesHttpParser
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+case class DesUri[Resp](uri: String)(implicit val responseReads: Reads[Resp])
+
+class DesService @Inject()(http: HttpClient, appConfig: AppConfig) {
+
+  private def desHeaderCarrier(implicit hc: HeaderCarrier): HeaderCarrier =
+    hc.copy(authorization = Some(Authorization(s"Bearer ${appConfig.desToken}")))
+      .withExtraHeaders("Environment" -> appConfig.desEnv)
+
+  def post[Body: Writes, Resp](body: Body, cmd: DesUri[Resp])(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[DesConnectorOutcome[Resp]] = {
+    implicit val parserReads: HttpReads[DesConnectorOutcome[Resp]] = StandardDesHttpParser.reads(cmd.responseReads)
+
+    def doPost(implicit hc: HeaderCarrier) =
+      http.POST(s"${appConfig.desBaseUrl}/${cmd.uri}", body)
+
+    doPost(desHeaderCarrier(hc))
+  }
+
+  def get[Resp](cmd: DesUri[Resp])(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[DesConnectorOutcome[Resp]] = {
+    implicit val parserReads: HttpReads[DesConnectorOutcome[Resp]] = StandardDesHttpParser.reads(cmd.responseReads)
+
+    def doGet(implicit hc: HeaderCarrier) =
+      http.GET(s"${appConfig.desBaseUrl}/${cmd.uri}")
+
+    doGet(desHeaderCarrier(hc))
+  }
+}

--- a/test/v2/controllers/IntentToCrystalliseControllerSpec.scala
+++ b/test/v2/controllers/IntentToCrystalliseControllerSpec.scala
@@ -21,11 +21,11 @@ import play.api.mvc.Result
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import v2.mocks.requestParsers.MockIntentToCrystalliseRequestDataParser
-import v2.mocks.services.{MockAuditService, MockCrystallisationService, MockEnrolmentsAuthService, MockMtdIdLookupService}
-import v2.models.audit.{AuditError, AuditEvent, IntentToCrystalliseAuditDetail, IntentToCrystalliseAuditResponse}
+import v2.mocks.services.{ MockAuditService, MockCrystallisationService, MockEnrolmentsAuthService, MockMtdIdLookupService }
+import v2.models.audit.{ AuditError, AuditEvent, IntentToCrystalliseAuditDetail, IntentToCrystalliseAuditResponse }
 import v2.models.errors._
 import v2.models.outcomes.DesResponse
-import v2.models.requestData.{DesTaxYear, IntentToCrystalliseRawData, IntentToCrystalliseRequestData}
+import v2.models.requestData.{ DesTaxYear, IntentToCrystalliseRawData, IntentToCrystalliseRequestData }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -47,6 +47,7 @@ class IntentToCrystalliseControllerSpec
       intentToCrystalliseRequestDataParser = mockIntentToCrystalliseRequestDataParser,
       crystallisationService = mockCrystallisationService,
       auditService = mockAuditService,
+      ???,
       cc = cc
     )
 
@@ -80,10 +81,15 @@ class IntentToCrystalliseControllerSpec
         header("Location", result).isEmpty shouldBe false
         header("Location", result) shouldBe Some(s"/self-assessment/ni/$nino/calculations/$calculationId")
 
-        val detail = IntentToCrystalliseAuditDetail("Individual", None, nino, taxYear, correlationId, Some(calculationId),
-          IntentToCrystalliseAuditResponse(SEE_OTHER, None))
-        val event: AuditEvent[IntentToCrystalliseAuditDetail] = AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise",
-          "intent-to-crystallise", detail)
+        val detail = IntentToCrystalliseAuditDetail("Individual",
+                                                    None,
+                                                    nino,
+                                                    taxYear,
+                                                    correlationId,
+                                                    Some(calculationId),
+                                                    IntentToCrystalliseAuditResponse(SEE_OTHER, None))
+        val event: AuditEvent[IntentToCrystalliseAuditDetail] =
+          AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise", "intent-to-crystallise", detail)
         MockedAuditService.verifyAuditEvent(event).once
       }
     }
@@ -99,10 +105,17 @@ class IntentToCrystalliseControllerSpec
         status(result) shouldBe BAD_REQUEST
         contentAsJson(result) shouldBe Json.toJson(ErrorWrapper(None, NinoFormatError, None))
 
-        val detail = IntentToCrystalliseAuditDetail("Individual", None, nino, taxYear, header("X-CorrelationId", result).get, None,
-          IntentToCrystalliseAuditResponse(BAD_REQUEST, Some(Seq(AuditError(NinoFormatError.code)))))
-        val event: AuditEvent[IntentToCrystalliseAuditDetail] = AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise",
-          "intent-to-crystallise", detail)
+        val detail = IntentToCrystalliseAuditDetail(
+          "Individual",
+          None,
+          nino,
+          taxYear,
+          header("X-CorrelationId", result).get,
+          None,
+          IntentToCrystalliseAuditResponse(BAD_REQUEST, Some(Seq(AuditError(NinoFormatError.code))))
+        )
+        val event: AuditEvent[IntentToCrystalliseAuditDetail] =
+          AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise", "intent-to-crystallise", detail)
         MockedAuditService.verifyAuditEvent(event).once
       }
     }
@@ -119,10 +132,17 @@ class IntentToCrystalliseControllerSpec
         contentAsJson(result) shouldBe Json.toJson(ErrorWrapper(None, BadRequestError, Some(Seq(NinoFormatError, TaxYearFormatError))))
         header("X-CorrelationId", result).nonEmpty shouldBe true
 
-        val detail = IntentToCrystalliseAuditDetail("Individual", None, nino, taxYear, header("X-CorrelationId", result).get, None,
-          IntentToCrystalliseAuditResponse(BAD_REQUEST, Some(Seq(AuditError(NinoFormatError.code), AuditError(TaxYearFormatError.code)))))
-        val event: AuditEvent[IntentToCrystalliseAuditDetail] = AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise",
-          "intent-to-crystallise", detail)
+        val detail = IntentToCrystalliseAuditDetail(
+          "Individual",
+          None,
+          nino,
+          taxYear,
+          header("X-CorrelationId", result).get,
+          None,
+          IntentToCrystalliseAuditResponse(BAD_REQUEST, Some(Seq(AuditError(NinoFormatError.code), AuditError(TaxYearFormatError.code))))
+        )
+        val event: AuditEvent[IntentToCrystalliseAuditDetail] =
+          AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise", "intent-to-crystallise", detail)
         MockedAuditService.verifyAuditEvent(event).once
       }
     }
@@ -191,10 +211,17 @@ class IntentToCrystalliseControllerSpec
         contentAsJson(result) shouldBe Json.toJson(error)
         header("X-CorrelationId", result) shouldBe Some(correlationId)
 
-        val detail = IntentToCrystalliseAuditDetail("Individual", None, nino, taxYear, header("X-CorrelationId", result).get, None,
-          IntentToCrystalliseAuditResponse(expectedStatus, Some(Seq(AuditError(error.code)))))
-        val event: AuditEvent[IntentToCrystalliseAuditDetail] = AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise",
-          "intent-to-crystallise", detail)
+        val detail = IntentToCrystalliseAuditDetail(
+          "Individual",
+          None,
+          nino,
+          taxYear,
+          header("X-CorrelationId", result).get,
+          None,
+          IntentToCrystalliseAuditResponse(expectedStatus, Some(Seq(AuditError(error.code))))
+        )
+        val event: AuditEvent[IntentToCrystalliseAuditDetail] =
+          AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise", "intent-to-crystallise", detail)
         MockedAuditService.verifyAuditEvent(event).once
       }
     }
@@ -216,10 +243,17 @@ class IntentToCrystalliseControllerSpec
         contentAsJson(result) shouldBe Json.toJson(error)
         header("X-CorrelationId", result) shouldBe Some(correlationId)
 
-        val detail = IntentToCrystalliseAuditDetail("Individual", None, nino, taxYear, header("X-CorrelationId", result).get, None,
-          IntentToCrystalliseAuditResponse(expectedStatus, Some(Seq(AuditError(error.code)))))
-        val event: AuditEvent[IntentToCrystalliseAuditDetail] = AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise",
-          "intent-to-crystallise", detail)
+        val detail = IntentToCrystalliseAuditDetail(
+          "Individual",
+          None,
+          nino,
+          taxYear,
+          header("X-CorrelationId", result).get,
+          None,
+          IntentToCrystalliseAuditResponse(expectedStatus, Some(Seq(AuditError(error.code))))
+        )
+        val event: AuditEvent[IntentToCrystalliseAuditDetail] =
+          AuditEvent[IntentToCrystalliseAuditDetail]("submitIntentToCrystallise", "intent-to-crystallise", detail)
         MockedAuditService.verifyAuditEvent(event).once
       }
     }


### PR DESCRIPTION
- allow common DesService with post/get
- allow removal of DesConnector
- DesResponseMappingSupport (simpler version of DesServiceSupport)
- use EitherT to separate happy path (and avoid repeated code handling for error paths)
- convert des success result to vendor result in controller
- convert des errors to vendor errors in controller

No TDD (unit tests will fail) but acceptance tests pass